### PR TITLE
Revert changes from https://github.com/Netflix/Hystrix/issues/1251

### DIFF
--- a/src/main/webapp/components/hystrixCommand/hystrixCommand.js
+++ b/src/main/webapp/components/hystrixCommand/hystrixCommand.js
@@ -115,7 +115,10 @@
 		function convertAllAvg(data) {
 			convertAvg(data, "errorPercentage", true);
 			convertAvg(data, "latencyExecute_mean", false);
-        }
+			
+			// the following will break when it becomes a compound string if the property is dynamically changed
+			convertAvg(data, "propertyValue_metricsRollingStatisticalWindowInMilliseconds", false);
+		}
 		
 		function convertAvg(data, key, decimal) {
 			if (decimal) {


### PR DESCRIPTION
Fixes https://github.com/Netflix/Hystrix/issues/1697.

After this fix dashboard will work for fine with Turbine 1.0 but it's still not compatible with Turbine 2.0. To support Turbine 2.0 we need separate ticket.